### PR TITLE
Hotfix for gitignore to remove ugly hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,11 +134,15 @@ dmypy.json
 static/photos/
 
 # Personal credentials for Edamam API
-# secrets/edamam.json
+secrets/**
+secrets/edamam.json
 
 heroku_key.pub
 heroku_key
 
-secrets/**
+.elasticbeanstalk
+.elasticbeanstalk/
 
 data/
+
+*Zone.Identifier


### PR DESCRIPTION
Removed .elasticbeanstalk folder, trying again to remove some files inside secrets