### PR TITLE
Feat #65: .gitignore PyCharm IDE support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,20 @@ data/
 
 # remove things inside joblib except README
 joblib/*.joblib
+
+### JetBrains PyCharm support
+
+# User-specific stuff:
+.idea/
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml


### PR DESCRIPTION
- Add JetBrains PyCharm support in .gitignore.