### PR TITLE
Attempt to fix correct file

### DIFF
--- a/src/nltk/dish_predictor.py
+++ b/src/nltk/dish_predictor.py
@@ -35,17 +35,11 @@ def import_stored_files():
     # Load in the stored Epicurious database, TFIDF Vectorizer object to transform,
     # the input, and the TFIDF word matrix from joblib and created by
     # prepare_database.py
-    with open("joblib/tfidf_recipe_dataframe.joblib", "rb") as fo:
-        prepped = joblib.load("joblib/tfidf_recipe_dataframe.joblib")
-        print(f"prepped dataframe size: {prepped.shape}")
+    prepped = joblib.load("joblib/tfidf_recipe_dataframe.joblib")
 
-    with open("joblib/recipe_tfidf.joblib", "rb") as fo:
-        ingred_tfidf = joblib.load("joblib/recipe_tfidf.joblib")
-        print(f"tfidf feature name size: {len(ingred_tfidf.get_feature_names())}")
+    ingred_tfidf = joblib.load("joblib/recipe_tfidf.joblib")
 
-    with open("joblib/recipe_word_matrix_tfidf.joblib", "rb") as fo:
-        ingred_word_matrix = joblib.load("joblib/recipe_word_matrix_tfidf.joblib")
-        print(f"word matrix size: {ingred_word_matrix.shape}")
+    ingred_word_matrix = joblib.load("joblib/recipe_word_matrix_tfidf.joblib")
 
     return prepped, ingred_tfidf, ingred_word_matrix
 
@@ -222,7 +216,7 @@ def find_similar_dishes(dish_name, cuisine_name):
 
     # Currently, just does an API call, may hit API limit if continuing with this
     # version
-    f = open("secrets/edamam.json", "r")
+    f = open("../secrets/edamam.json", "r")
     cred = json.load(f)
     f.close()
 
@@ -241,6 +235,7 @@ def find_similar_dishes(dish_name, cuisine_name):
     api_call = api_base + q + app_id_s + app_key_s  # + limiter
 
     resp = requests.get(api_call)
+    print(f"response status code: {resp.status_code}")
 
     if resp.status_code == 200:
         response_dict = resp.json()
@@ -323,7 +318,5 @@ def find_similar_dishes(dish_name, cuisine_name):
         return query_similar.to_dict(orient="records"), ingreds_used, recipe_weights
 
     else:
-        return (
-            "Error, unable to retrieve. Server response code is: ",
-            resp.status_code,
-        )
+        print(f"Error, unable to retrieve. Server response code is: {resp.status_code}")
+        return ([[]], [[]], [[]])

--- a/src/nltk/find_similar_dishes.py
+++ b/src/nltk/find_similar_dishes.py
@@ -94,7 +94,13 @@ def find_closest_recipes(filtered_ingred_word_matrix, recipe_tfidf, X_df):
 
 
 def __main__(dish_name, cuisine_name):
+    # import pickled files
     prepped, ingred_tfidf, ingred_word_matrix = import_stored_files()
+
+    print(f"prepped dataframe size: {prepped.shape}\n")
+    print(f"number of ingredients: {len(ingred_tfidf)}\n")
+    print(f"word matrix size: {ingred_word_matrix.shape}\n")
+
     # This function calls the Edamam API, stores the results as a JSON, and
     # stores the timestamp, dish name, and cuisine name/classification in a
     # separate csv.
@@ -119,8 +125,7 @@ def __main__(dish_name, cuisine_name):
 
     # Currently, just does an API call, may hit API limit if continuing with this
     # version
-    with open("../secrets/edamam.json", "r") as f:
-        cred = json.load(f)
+    cred = json.load("../secrets/edamam.json")
 
     app_id = cred["id"]
     app_id_s = f"&app_id=${app_id}"
@@ -134,9 +139,11 @@ def __main__(dish_name, cuisine_name):
     # limiter = "&from=0&to=4"
     # API currently defaults to returning 10
 
+    print(f"query base: {api_base}{q}")
     api_call = api_base + q + app_id_s + app_key_s  # + limiter
 
     resp = requests.get(api_call)
+    print(f"response status code: {resp.status_code}")
 
     if resp.status_code == 200:
         response_dict = resp.json()
@@ -181,6 +188,7 @@ def __main__(dish_name, cuisine_name):
                 one_recipe.append(ingred.lower())
 
         one_recipe = list(set(one_recipe))
+        print(one_recipe)
 
         query_df = pd.DataFrame(
             data={"name": search_q, "ingredients": [one_recipe], "cuisine": cuisine_q}


### PR DESCRIPTION
diff --git a/src/nltk/dish_predictor.py b/src/nltk/dish_predictor.py index a2aeb6a..485d517 100644
--- a/src/nltk/dish_predictor.py
+++ b/src/nltk/dish_predictor.py
@@ -35,17 +35,11 @@ def import_stored_files():
     # Load in the stored Epicurious database, TFIDF Vectorizer object to transform,
     # the input, and the TFIDF word matrix from joblib and created by
     # prepare_database.py
-    with open("joblib/tfidf_recipe_dataframe.joblib", "rb") as fo:
-        prepped = joblib.load("joblib/tfidf_recipe_dataframe.joblib")
-        print(f"prepped dataframe size: {prepped.shape}")
+    prepped = joblib.load("joblib/tfidf_recipe_dataframe.joblib")

-    with open("joblib/recipe_tfidf.joblib", "rb") as fo:
-        ingred_tfidf = joblib.load("joblib/recipe_tfidf.joblib")
-        print(f"tfidf feature name size: {len(ingred_tfidf.get_feature_names())}")
+    ingred_tfidf = joblib.load("joblib/recipe_tfidf.joblib")

-    with open("joblib/recipe_word_matrix_tfidf.joblib", "rb") as fo:
-        ingred_word_matrix = joblib.load("joblib/recipe_word_matrix_tfidf.joblib")
-        print(f"word matrix size: {ingred_word_matrix.shape}")
+    ingred_word_matrix = joblib.load("joblib/recipe_word_matrix_tfidf.joblib")

     return prepped, ingred_tfidf, ingred_word_matrix

@@ -222,7 +216,7 @@ def find_similar_dishes(dish_name, cuisine_name):

     # Currently, just does an API call, may hit API limit if continuing with this
     # version
-    f = open("secrets/edamam.json", "r")
+    f = open("../secrets/edamam.json", "r")
     cred = json.load(f)
     f.close()

@@ -241,6 +235,7 @@ def find_similar_dishes(dish_name, cuisine_name):
     api_call = api_base + q + app_id_s + app_key_s  # + limiter

     resp = requests.get(api_call)
+    print(f"response status code: {resp.status_code}")

     if resp.status_code == 200:
         response_dict = resp.json()
@@ -323,7 +318,5 @@ def find_similar_dishes(dish_name, cuisine_name):
         return query_similar.to_dict(orient="records"), ingreds_used, recipe_weights

     else:
-        return (
-            "Error, unable to retrieve. Server response code is: ",
-            resp.status_code,
-        )
+        print(f"Error, unable to retrieve. Server response code is: {resp.status_code}")
+        return ([[]], [[]], [[]])
diff --git a/src/nltk/find_similar_dishes.py b/src/nltk/find_similar_dishes.py
index c0bac1c..7160a9a 100644
--- a/src/nltk/find_similar_dishes.py
+++ b/src/nltk/find_similar_dishes.py
@@ -94,7 +94,13 @@ def find_closest_recipes(filtered_ingred_word_matrix, recipe_tfidf, X_df):

 def __main__(dish_name, cuisine_name):
+    # import pickled files
     prepped, ingred_tfidf, ingred_word_matrix = import_stored_files()
+
+    print(f"prepped dataframe size: {prepped.shape}\n")
+    print(f"number of ingredients: {len(ingred_tfidf)}\n")
+    print(f"word matrix size: {ingred_word_matrix.shape}\n")
+
     # This function calls the Edamam API, stores the results as a JSON, and
     # stores the timestamp, dish name, and cuisine name/classification in a
     # separate csv.
@@ -119,8 +125,7 @@ def __main__(dish_name, cuisine_name):

     # Currently, just does an API call, may hit API limit if continuing with this
     # version
-    with open("../secrets/edamam.json", "r") as f:
-        cred = json.load(f)
+    cred = json.load("../secrets/edamam.json")

     app_id = cred["id"]
     app_id_s = f"&app_id=${app_id}"
@@ -134,9 +139,11 @@ def __main__(dish_name, cuisine_name):
     # limiter = "&from=0&to=4"
     # API currently defaults to returning 10

+    print(f"query base: {api_base}{q}")
     api_call = api_base + q + app_id_s + app_key_s  # + limiter

     resp = requests.get(api_call)
+    print(f"response status code: {resp.status_code}")

     if resp.status_code == 200:
         response_dict = resp.json()
@@ -181,6 +188,7 @@ def __main__(dish_name, cuisine_name):
                 one_recipe.append(ingred.lower())

         one_recipe = list(set(one_recipe))
+        print(one_recipe)

         query_df = pd.DataFrame(
             data={"name": search_q, "ingredients": [one_recipe], "cuisine": cuisine_q}